### PR TITLE
Mute warnings.

### DIFF
--- a/public/serve.php
+++ b/public/serve.php
@@ -15,8 +15,8 @@ if($_GET['ih']) {
 
 	if(strlen($ih) == 40) {
 		$loc = $GLOBALS['LOCATION'].$ih.'.torrent';
-		$exists = (file_exists($loc))?true:false;
-		$notnull = (filesize($loc)>0)?true:false;
+		$exists = (@file_exists($loc))?true:false;
+		$notnull = (@filesize($loc)>0)?true:false;
 
 		if($exists) {
 			$diff = time()-filemtime($loc);


### PR DESCRIPTION
If the cached file does not yet exist, PHP (depending on error_level) will throw an annoying warning in the error log.
