### PR TITLE
Redirect requests for /torrents/ to the root index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration
         server_name reflektor.karmorra.info;
     
         rewrite ^/torrent/(.+)\.torrent$ /serve.php?ih=$1 last;
+        rewrite ^/torrent/?$ / redirect;
     
     	location /torrents/ {
     		internal;


### PR DESCRIPTION
Rather than an ugly 404 and pointless line in the error log, just
redirect visitors to /torrents or /torrents/ to /
